### PR TITLE
Use Environ to access environment variables.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,11 +27,13 @@
                  [org.clojure/java.jdbc "0.3.6"]
                  [postgresql "9.3-1102.jdbc41"]
                  [ragtime "0.3.8"]
+                 [environ "1.0.0"]
                  [endophile "0.1.2"]
                  [org.pegdown/pegdown "1.2.0"]
                  [clojure-csv/clojure-csv "2.0.1"]]
   :main objective8.core
-  :plugins [[ragtime/ragtime.lein "0.3.8"]]
+  :plugins [[ragtime/ragtime.lein "0.3.8"]
+            [lein-environ "1.0.0"]]
   :profiles {:dev {:source-paths ["dev"]
                    :repl-options {:init-ns user
                                   :timeout 120000}

--- a/src/objective8/config.clj
+++ b/src/objective8/config.clj
@@ -1,19 +1,6 @@
 (ns objective8.config
- (:require [clojure.tools.logging :as log]))
+ (:require [environ.core :as environ]))
 
 (def ^:dynamic enable-csrf true)
 
-(defn- env-lookup [var-name]
-  (get (System/getenv) var-name))
-
-(defn get-var 
-  "Attempts to read an environment variable. If no variable is
-  found will log a warning message and use the default. If no
-  default is provided will use nil"
-  ([var-name]
-   (get-var var-name nil))
-  ([var-name default] 
-  (if-let [variable (get (System/getenv) var-name)]
-    variable
-    (do (log/warn (str "Failed to look up environment variable \"" var-name "\""))
-        default))))
+(def get-var environ/env)


### PR DESCRIPTION
This should help address the problem with the app crashing when environment variables aren't loaded, as they can be defaulted in a config file somewhere. This is a start of implementing #8.

This has _not_ been properly tested. :-)
